### PR TITLE
Enforce get method for validation checks

### DIFF
--- a/views/pyenv_wrapper/config.erb
+++ b/views/pyenv_wrapper/config.erb
@@ -5,7 +5,7 @@ f.entry(:title => "The Python version", :field => "version") do
   # descendant of hudson.model.Descriptor.
   # Since JRuby objects do not respond to Java refrections expectedly,
   # we must specify :checkUrl explicitly as an option of textbox.
-  f.textbox(:default => descriptor.class.const_get(:DEFAULT_VERSION), :checkUrl => "'#{rootURL}/descriptorByName/pyenv-PyenvWrapper/checkVersion?value='+encodeURIComponent(this.value)")
+  f.textbox(:default => descriptor.class.const_get(:DEFAULT_VERSION), :checkMethod => "get", :checkUrl => "'#{rootURL}/descriptorByName/pyenv-PyenvWrapper/checkVersion?value='+encodeURIComponent(this.value)")
 end
 f.advanced do
   f.entry(:title => "Ignore local version", :field => "ignore_local_version") do
@@ -17,7 +17,7 @@ f.entry(:title => "Preinstall pip list", :field => "pip_list") do
 end
 f.advanced do
   f.entry(:title => "PYENV_ROOT", :field => "pyenv_root") do
-    f.textbox(:default => descriptor.class.const_get(:DEFAULT_PYENV_ROOT), :checkUrl => "'#{rootURL}/descriptorByName/pyenv-PyenvWrapper/checkPyenvRoot?value='+encodeURIComponent(this.value)")
+    f.textbox(:default => descriptor.class.const_get(:DEFAULT_PYENV_ROOT), :checkMethod => "get",:checkUrl => "'#{rootURL}/descriptorByName/pyenv-PyenvWrapper/checkPyenvRoot?value='+encodeURIComponent(this.value)")
   end
   f.entry(:title => "pyenv.git", :field => "pyenv_repository") do
     f.textbox(:default => descriptor.class.const_get(:DEFAULT_PYENV_REPOSITORY))


### PR DESCRIPTION
The following change enforces the use of get in the form validation instead of post which was recently introduced by default and it's breaking the plugin functionality.

- [ X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ X] Link to relevant issues in GitHub or Jira
- [ X] Link to relevant pull requests, esp. upstream and downstream changes
- [ X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


Related issue: https://issues.jenkins.io/browse/JENKINS-65790